### PR TITLE
fix(aws): create a layer in the region specified by AwsOptions

### DIFF
--- a/src/aws/aws-faast.ts
+++ b/src/aws/aws-faast.ts
@@ -367,7 +367,7 @@ export async function createLayer(
     packageJson: string | object | undefined,
     useDependencyCaching: boolean,
     FunctionName: string,
-    region: string
+    region: AwsRegion
 ): Promise<AwsLayerInfo | undefined> {
     if (!packageJson) {
         return;
@@ -398,6 +398,7 @@ export async function createLayer(
 
     try {
         const faastModule = await faastAws(awsNpm, {
+            region,
             timeout: 300,
             memorySize: 2048,
             mode: "https",


### PR DESCRIPTION
Currently, a lambda layer is always created by a temporary lambda function in ***us-west-2*** even if other region is specified .
This behavior makes debug difficult because logs are scattered in multiple regions.
Also, in my project, we want to give members permissions to use only a certain region, but we can't.

This PR causes faast.js to use the region specified in AwsOptions.