### PR TITLE
fix(aws): fix ensureRoleRaw to skip role creation when cached role is found

### DIFF
--- a/src/aws/aws-faast.ts
+++ b/src/aws/aws-faast.ts
@@ -377,6 +377,7 @@ export async function ensureRoleRaw(
         if (!response.Role) {
             throw new Error();
         }
+        return response.Role!;
     } catch (err) {
         if (!createRole) {
             throw new FaastError(


### PR DESCRIPTION
Before the commit fe8a7a4286597a2f2cd4b7ee5f4a61902f2a8eb4, initialization process skips creating default role if the cached lambda role is found. Currently it always tries to create role, so it fails if the User is not allowed to create a role. We want to minimize the privilege, by creating the cached role beforehand.